### PR TITLE
Release 2.1.0

### DIFF
--- a/OctoPrint/config.yaml
+++ b/OctoPrint/config.yaml
@@ -1,37 +1,229 @@
-appearance:
-  name: Kamikaze 2.1.0 RC4
+actions: {}
+api:
+  key: 43914750914748C89E65190FA6A36F3F
+appearance: 
+  name: Kamikaze_2.1.0_RC4
+controls:
+- children:
+  - commands:
+    - M906 X%(current_x)s
+    - M909 X%(microstepping_x)s
+    input:
+    - default: 500
+      name: Current X
+      parameter: current_x
+      slider:
+        max: 2500
+        min: 1
+        step: 1
+    - default: 4
+      name: Microstepping X
+      parameter: microstepping_x
+      slider:
+        max: 7
+        min: 0
+        step: 1
+    layout: vertical
+    name: Set
+  - commands:
+    - M906 Y%(current_y)s
+    - M909 Y%(microstepping_y)s
+    input:
+    - default: 500
+      name: Current Y
+      parameter: current_y
+      slider:
+        max: 2500
+        min: 1
+        step: 1
+    - default: 4
+      name: Microstepping Y
+      parameter: microstepping_y
+      slider:
+        max: 7
+        min: 0
+        step: 1
+    layout: vertical
+    name: Set
+  - commands:
+    - M906 Z%(current_z)s
+    - M909 Z%(microstepping_z)s
+    input:
+    - default: 500
+      name: Current Z
+      parameter: current_z
+      slider:
+        max: 2500
+        min: 1
+        step: 1
+    - default: 4
+      name: Microstepping Z
+      parameter: microstepping_z
+      slider:
+        max: 7
+        min: 0
+        step: 1
+    layout: vertical
+    name: Set
+  - commands:
+    - M906 E%(current_e)s
+    - M909 E%(microstepping_e)s
+    input:
+    - default: 500
+      name: Current E
+      parameter: current_e
+      slider:
+        max: 2500
+        min: 1
+        step: 1
+    - default: 4
+      name: Microstepping E
+      parameter: microstepping_e
+      slider:
+        max: 7
+        min: 0
+        step: 1
+    layout: vertical
+    name: Set
+  - commands:
+    - M906 H%(current_h)s
+    - M909 H%(microstepping_h)s
+    input:
+    - default: 500
+      name: Current H
+      parameter: current_h
+      slider:
+        max: 2500
+        min: 1
+        step: 1
+    - default: 4
+      name: Microstepping H
+      parameter: microstepping_h
+      slider:
+        max: 7
+        min: 0
+        step: 1
+    layout: vertical
+    name: Set
+  layout: vertical
+  name: Stepper current and microstepping
+- children:
+  - commands:
+    - M569 X%(direction_x)s
+    - M92  X%(steps_pr_mm_x)s
+    input:
+    - default: 10
+      name: Steps pr mm X
+      parameter: steps_pr_mm_x
+    - default: 1
+      name: Invert X
+      parameter: direction_x
+      slider:
+        max: 1
+        min: -1
+        step: 2
+    layout: vertical
+    name: Set
+  - commands:
+    - M569 Y%(direction_y)s
+    - M92  Y%(steps_pr_mm_y)s
+    input:
+    - default: 10
+      name: Steps pr mm Y
+      parameter: steps_pr_mm_y
+    - default: 1
+      name: Invert Y
+      parameter: direction_y
+      slider:
+        max: 1
+        min: -1
+        step: 2
+    layout: vertical
+    name: Set
+  - commands:
+    - M569 Z%(direction_z)s
+    - M92  Z%(steps_pr_mm_z)s
+    input:
+    - default: 10
+      name: Steps pr mm Z
+      parameter: steps_pr_mm_z
+    - default: 1
+      name: Invert Z
+      parameter: direction_z
+      slider:
+        max: 1
+        min: -1
+        step: 2
+    layout: vertical
+    name: Set
+  - commands:
+    - M569 E%(direction_e)s
+    - M92  E%(steps_pr_mm_e)s
+    input:
+    - default: 10
+      name: Steps pr mm E
+      parameter: steps_pr_mm_e
+    - default: 1
+      name: Invert E
+      parameter: direction_e
+      slider:
+        max: 1
+        min: -1
+        step: 2
+    layout: vertical
+    name: Set
+  - commands:
+    - M569 H%(direction_h)s
+    - M92  H%(steps_pr_mm_h)s
+    input:
+    - default: 10
+      name: Steps pr mm H
+      parameter: steps_pr_mm_h
+    - default: 1
+      name: Invert H
+      parameter: direction_h
+      slider:
+        max: 1
+        min: -1
+        step: 2
+    layout: vertical
+    name: Set
+  layout: vertical
+  name: Stepper steps pr mm and direction
 feature: {}
 folder:
   uploads: /usr/share/models
 gcodeViewer: {}
 plugins:
   cura:
-    _config_version: null
     cura_engine: /usr/bin/CuraEngine
-    debug_logging: false
-    default_profile: null
+  discovery:
+    upnpUuid: e828df1e-22e8-4201-8a84-1281df64b854
   softwareupdate:
     _config_version: 4
+    check_providers:
+      slicer: slicer
     checks:
+      Kamikaze:
+        checkout_folder: /usr/src/Kamikaze2
+        restart: echo "Kamikaze dummy restart"
+        type: git_commit
+        update_script: /usr/src/Kamikaze2/update-kamikaze.sh
       Redeem:
         checkout_folder: /usr/src/redeem
+        restart: echo "Redeem dummy restart"
         type: git_commit
-        update_script: '{python} "/usr/src/redeem/update-redeem.py" --python="{python}" --sudo "{folder}" "{target}"'
-        restart: 'echo "Redeem dummy restart"'
+        update_script: '{python} "/usr/src/redeem/update-redeem.py" --python="{python}"
+          --sudo "{folder}" "{target}"'
       Toggle:
         checkout_folder: /usr/src/toggle
+        restart: echo "Toggle dummy restart"
         type: git_commit
-        update_script: '{python} "/usr/src/toggle/update-toggle.py" --python="{python}" "{folder}" "{target}"'
-        restart: 'echo "Toggle dummy restart"'
+        update_script: '{python} "/usr/src/toggle/update-toggle.py" --python="{python}"
+          "{folder}" "{target}"'
       octoprint:
         checkout_folder: /home/octo/OctoPrint
         prerelease: false
-        type: github_release
-      Kamikaze:
-        checkout_folder: /usr/src/Kamikaze2
-        type: git_commit
-        update_script: '/usr/src/Kamikaze2/update-kamikaze.sh'
-        restart: 'echo "Kamikaze dummy restart"'
 printerParameters: {}
 serial:
   additionalPorts:
@@ -39,209 +231,22 @@ serial:
   baudrate: 115200
   port: /dev/octoprint_1
   timeout: {}
-system: {}
+server:
+  commands:
+    systemRestartCommand: sudo reboot
+    systemShutdownCommand: sudo shutdown -h now
+  secretKey: ZRXPeXLCqdsI7Isrx4E5W7Mvi5uXja3z
+system:
+  actions:
+  - action: divider
+  - action: restart_redeem
+    command: sudo systemctl restart redeem.service
+    name: Restart Redeem
+  - action: restart_octoprint
+    command: sudo systemctl restart octoprint.service
+    name: Restart Octoprint
+  - action: restart_toggle
+    command: sudo systemctl restart toggle.service
+    name: Restart Toggle
 temperature: {}
 webcam: {}
-controls:
-  - name: Stepper current and microstepping
-    layout: vertical
-    children:
-    - name: Set
-      layout: vertical
-      commands: 
-       - M906 X%(current_x)s
-       - M909 X%(microstepping_x)s
-      input:
-      - default: 500
-        name: Current X
-        parameter: current_x
-        slider:
-          max: 2500
-          min: 1
-          step: 1
-      - default: 4
-        name: Microstepping X
-        parameter: microstepping_x
-        slider:
-          max: 7
-          min: 0
-          step: 1
-    - name: Set
-      layout: vertical
-      commands: 
-       - M906 Y%(current_y)s
-       - M909 Y%(microstepping_y)s
-      input:
-      - default: 500
-        name: Current Y
-        parameter: current_y
-        slider:
-          max: 2500
-          min: 1
-          step: 1
-      - default: 4
-        name: Microstepping Y
-        parameter: microstepping_y
-        slider:
-          max: 7
-          min: 0
-          step: 1
-    - name: Set
-      layout: vertical
-      commands: 
-       - M906 Z%(current_z)s
-       - M909 Z%(microstepping_z)s
-      input:
-      - default: 500
-        name: Current Z
-        parameter: current_z
-        slider:
-          max: 2500
-          min: 1
-          step: 1
-      - default: 4
-        name: Microstepping Z
-        parameter: microstepping_z
-        slider:
-          max: 7
-          min: 0
-          step: 1
-    - name: Set
-      layout: vertical
-      commands: 
-       - M906 E%(current_e)s
-       - M909 E%(microstepping_e)s
-      input:
-      - default: 500
-        name: Current E
-        parameter: current_e
-        slider:
-          max: 2500
-          min: 1
-          step: 1
-      - default: 4
-        name: Microstepping E
-        parameter: microstepping_e
-        slider:
-          max: 7
-          min: 0
-          step: 1
-    - name: Set
-      layout: vertical
-      commands: 
-       - M906 H%(current_h)s
-       - M909 H%(microstepping_h)s
-      input:
-      - default: 500
-        name: Current H
-        parameter: current_h
-        slider:
-          max: 2500
-          min: 1
-          step: 1
-      - default: 4
-        name: Microstepping H
-        parameter: microstepping_h
-        slider:
-          max: 7
-          min: 0
-          step: 1
-  - name: Stepper steps pr mm and direction
-    layout: vertical
-    children:
-    - name: Set
-      layout: vertical
-      commands: 
-       - M569 X%(direction_x)s
-       - M92  X%(steps_pr_mm_x)s
-      input:
-      - default: 10
-        name: Steps pr mm X
-        parameter: steps_pr_mm_x
-      - default: 1
-        name: Invert X
-        parameter: direction_x
-        slider:
-          max: 1
-          min: -1
-          step: 2
-    - name: Set
-      layout: vertical
-      commands: 
-       - M569 Y%(direction_y)s
-       - M92  Y%(steps_pr_mm_y)s
-      input:
-      - default: 10
-        name: Steps pr mm Y
-        parameter: steps_pr_mm_y
-      - default: 1
-        name: Invert Y
-        parameter: direction_y
-        slider:
-          max: 1
-          min: -1
-          step: 2
-    - name: Set
-      layout: vertical
-      commands: 
-       - M569 Z%(direction_z)s
-       - M92  Z%(steps_pr_mm_z)s
-      input:
-      - default: 10
-        name: Steps pr mm Z
-        parameter: steps_pr_mm_z
-      - default: 1
-        name: Invert Z
-        parameter: direction_z
-        slider:
-          max: 1
-          min: -1
-          step: 2
-    - name: Set
-      layout: vertical
-      commands: 
-       - M569 E%(direction_e)s
-       - M92  E%(steps_pr_mm_e)s
-      input:
-      - default: 10
-        name: Steps pr mm E
-        parameter: steps_pr_mm_e
-      - default: 1
-        name: Invert E
-        parameter: direction_e
-        slider:
-          max: 1
-          min: -1
-          step: 2
-    - name: Set
-      layout: vertical
-      commands: 
-       - M569 H%(direction_h)s
-       - M92  H%(steps_pr_mm_h)s
-      input:
-      - default: 10
-        name: Steps pr mm H
-        parameter: steps_pr_mm_h
-      - default: 1
-        name: Invert H
-        parameter: direction_h
-        slider:
-          max: 1
-          min: -1
-          step: 2
-actions:
- - action: Restart Redeem
-   command: sudo systemctl restart redeem
-   name: Restart Redeem
- - action: Restart Octoprint
-   command: sudo systemctl restart octoprint
-   name: Restart Octoprint
- - action: Restart Toggle
-   command: sudo systemctl restart toggle
-   name: Restart Toggle
-- action: Shutdown
-   command: sudo shutdown -h now
-   name: Shutdown
- - action: Reboot
-   command: sudo shutdown -r now
-   name: Reboot

--- a/OctoPrint/config.yaml
+++ b/OctoPrint/config.yaml
@@ -228,3 +228,19 @@ controls:
           max: 1
           min: -1
           step: 2
+actions:
+ - action: Restart Redeem
+   command: sudo systemctl restart redeem
+   name: Restart Redeem
+ - action: Restart Octoprint
+   command: sudo systemctl restart octoprint
+   name: Restart Octoprint
+ - action: Restart Toggle
+   command: sudo systemctl restart toggle
+   name: Restart Toggle
+- action: Shutdown
+   command: sudo shutdown -h now
+   name: Shutdown
+ - action: Reboot
+   command: sudo shutdown -r now
+   name: Reboot

--- a/OctoPrint/config.yaml
+++ b/OctoPrint/config.yaml
@@ -1,4 +1,5 @@
-appearance: {}
+appearance:
+  name: Kamikaze 2.1.0 RC4
 feature: {}
 folder:
   uploads: /usr/share/models

--- a/generate-image-from-sd.sh
+++ b/generate-image-from-sd.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# This script currently does not have error checking in it and has not been heavily tested.
+#   use this script at your own risk.
+#
+#   If you are debugging or just concerned uncomment the "set -e" line below to force the script to
+#   terminate on any error. This includes erroring on already existing directories and similar minor issues.
+
+#set -e
+
+echo
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "! This script currently does not have error checking in it and has not been heavily tested. !"
+echo "!         As such use this script at your own risk till it can be refined further.          !"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo
+echo "This script will resize the file system and partition on the SD card to as small as possible."
+echo "After this it will clone the results to an image file on USB drive"
+echo
+echo "Please make sure the SD card and FAT formatted USB drive are inserted."
+read -rsp $'Press any key to continue...\n' -n1 key
+
+# This is commended out because it currently cannot work, the script shuts the BB down after running
+#echo "Running script to clone eMMC to SD"
+#echo "/opt/scripts/tools/eMMC/beaglebone-black-make-microSD-flasher-from-eMMC.sh"
+echo
+
+# This makes it so the image will boot on other BB not just the one it was built on
+echo "Removing UUID from /boot/uEnv.txt"
+mkdir /mnt/zero
+mount /dev/mmcblk1p1 /mnt/zero
+sed -ie '/^uuid=/d' /mnt/zero/boot/uEnv.txt
+echo
+
+# Likely not needed but for the sake of making the image smaller we defrag first
+echo "Defragmenting partition."
+e4defrag /mnt/zero > /dev/null
+umount /mnt/zero
+echo
+
+# Run file system checks and then shrink the file system as much as possible
+echo "Resizing filesystem."
+e2fsck -f /dev/mmcblk1p1
+resize2fs -pM /dev/mmcblk1p1
+resize2fs -pM /dev/mmcblk1p1
+e2fsck -f /dev/mmcblk1p1
+echo
+
+# Zero out the free space remaining on the file system
+echo "Defrag and zero partition free space."
+mount /dev/mmcblk1p1 /mnt/zero
+e4defrag /mnt/zero > /dev/null
+dd if=/dev/zero of=/mnt/zero/zeros
+rm -rf /mnt/zero/zeros
+umount /mnt/zero
+echo
+
+# Run the file system checks and another series of file system shrinks just in case
+#   we can shrink the file system any further after zeroing the free space.
+echo "Resizing filesystem again."
+e2fsck -f /dev/mmcblk1p1
+resize2fs -pM /dev/mmcblk1p1
+resize2fs -pM /dev/mmcblk1p1
+e2fsck -f /dev/mmcblk1p1
+echo
+
+# This is where the real danger starts with modifying the partitions
+echo "Shrinking partition now."
+# Gather useful partition data
+fsblockcount=$(tune2fs -l /dev/mmcblk1p1 | grep "Block count:" | awk '{printf $3}')
+fsblocksize=$(tune2fs -l /dev/mmcblk1p1 | grep "Block size:" | awk '{printf $3}')
+partblocksize=$(fdisk -l /dev/mmcblk1p1 | grep Units: | awk '{printf $8}')
+partblockstart=$(fdisk -l /dev/mmcblk1 | grep /dev/mmcblk1p1 | awk '{printf $3}')
+partsize=$((fsblockcount*fsblocksize/partblocksize))
+
+# Write out the partition layout that will replace the currently existing one.
+cat <<EOF > /shrink.layout
+# partition table of /dev/mmcblk1
+unit: sectors
+
+/dev/mmcblk1p1 : start=${partblockstart}, size=${partsize}, Id=83, bootable
+EOF
+
+# Perform actual modificaitons to the partition layout
+sfdisk /dev/mmcblk1 < /shrink.layout
+rm -rf /shrink.layout
+
+# Make sure the system sees the new partition layout, check the file system for issues
+#   and then resize the file system to the full size of the new partition if it is needed
+echo "Probing partitions"
+partprobe
+e2fsck -f /dev/mmcblk1p1
+resize2fs /dev/mmcblk1p1
+e2fsck -f /dev/mmcblk1p1
+echo
+
+# Run one last defrag and zero of the free space before backing it up
+echo "Final defrag and zeroing partition free space."
+mount /dev/mmcblk1p1 /mnt/zero
+e4defrag /mnt/zero > /dev/null
+dd if=/dev/zero of=/mnt/zero/zeros
+rm -rf /mnt/zero/zeros
+umount /mnt/zero
+rm -rf /mnt/zero
+echo
+
+# Final file system check
+echo "File system and partition shrink are complete, running last file system check."
+e2fsck -f /dev/mmcblk1p1
+echo
+
+# Mounting the USB thumb drive and generating the compressed image file on it from the sd card
+echo "Generating image file now."
+ddblocksize=$(fdisk -l /dev/mmcblk1 | grep Units: | awk '{printf $8}')
+ddcount=$(fdisk -l /dev/mmcblk1 | grep /dev/mmcblk1p1 | awk '{printf $4}')
+kamiversion=$(cat /etc/dogtag | awk '{printf $2}')
+mkdir /mnt/USB
+mount /dev/sda1 /mnt/USB
+dd if=/dev/mmcblk1 bs=${ddblocksize} count=${ddcount} | xz > /mnt/USB/Kamikaze-${kamiversion}.img.xz
+umount /mnt/USB
+rm -rf /mnt/USB
+echo
+
+# Talkie talkie
+echo "Image file generated on USB drive as Kamikaze-${kamiversion}.img.xz"
+echo "USB drive and MicroSD card can be removed safely now."
+echo "This BeagleBone has been imaged and can now either be shut down or used normally."

--- a/interfaces
+++ b/interfaces
@@ -6,8 +6,8 @@ auto lo
 iface lo inet loopback
 
 # The primary network interface
-auto eth0
-iface eth0 inet dhcp
+#auto eth0
+#iface eth0 inet dhcp
 # Example to keep MAC address between reboots
 #hwaddress ether DE:AD:BE:EF:CA:FE
 

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -123,7 +123,7 @@ install_redeem() {
 	cd redeem
 	git pull
 	python setup.py clean install
-
+	cp -r configs /etc/redeem
 	# Make profiles uploadable via Octoprint
 	touch /etc/redeem/local.cfg
 	chown -R octo:octo /etc/redeem/
@@ -243,6 +243,7 @@ install_toggle() {
     	fi
 	cd toggle
 	python setup.py clean install
+	cp -r configs /etc/toggle
 	# Make it writable for updates
 	chown -R octo:octo /usr/src/toggle/
 	cp systemd/toggle.service /lib/systemd/system/

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -147,9 +147,9 @@ create_user() {
 	mkdir /home/octo/.octoprint
 	useradd -G "${default_groups}" -s /bin/bash -m -p octo -c "OctoPrint" octo
 	chown -R octo:octo /home/octo
-	chown -R octo:octo /usr/local/lib/python2.7/dist-packages
+	chown -R octo:octo /usr/local/lib/python2.7/
 	chown -R octo:octo /usr/local/bin
-	chmod 755 -R /usr/local/lib/python2.7/dist-packages
+	chmod 755 -R /usr/local/lib/python2.7/
 }
 
 install_octoprint() {
@@ -159,6 +159,8 @@ install_octoprint() {
 	     #su - octo -c "git clone --branch ${OCTORELEASE} --depth 1 https://github.com/foosel/OctoPrint.git"
 	     su - octo -c "git clone --depth 1 https://github.com/foosel/OctoPrint.git"
     fi
+	chown -R octo:octo /usr/local/lib/python2.7/dist-packages/
+	chown -R octo:octo /usr/local/bin/
 	su - octo -c 'cd OctoPrint && python setup.py clean install'
 	su - octo -c 'pip install https://github.com/Salandora/OctoPrint-FileManager/archive/master.zip --user'
 	su - octo -c 'pip install https://github.com/kennethjiang/OctoPrint-Slicer/archive/master.zip --user'

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -156,7 +156,8 @@ install_octoprint() {
 	echo "** Install OctoPrint **" 
 	cd /home/octo
     if [ ! -d "OctoPrint" ]; then
-	     su - octo -c "git clone --branch ${OCTORELEASE} --depth 1 https://github.com/foosel/OctoPrint.git"
+	     #su - octo -c "git clone --branch ${OCTORELEASE} --depth 1 https://github.com/foosel/OctoPrint.git"
+	     su - octo -c "git clone --depth 1 https://github.com/foosel/OctoPrint.git"
     fi
 	su - octo -c 'cd OctoPrint && python setup.py clean install'
 	su - octo -c 'pip install https://github.com/Salandora/OctoPrint-FileManager/archive/master.zip --user'

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -1,4 +1,4 @@
-/bash
+#!/bin/bash
 
 #
 # base is https://rcn-ee.com/rootfs/2016-11-10/flasher/BBB-eMMC-flasher-ubuntu-16.04.1-console-armhf-2016-11-10-2gb.img.xz
@@ -42,6 +42,7 @@
 
 WD=`pwd`/
 VERSION="Kamikaze 2.1.0"
+OCTORELEASE=1.3.1
 DATE=`date`
 echo "**Making ${VERSION}**"
 
@@ -156,8 +157,7 @@ install_octoprint() {
 	echo "** Install OctoPrint **" 
 	cd /home/octo
     if [ ! -d "OctoPrint" ]; then
-	     #su - octo -c "git clone --branch ${OCTORELEASE} --depth 1 https://github.com/foosel/OctoPrint.git"
-	     su - octo -c "git clone --depth 1 https://github.com/foosel/OctoPrint.git"
+	     su - octo -c "git clone --branch ${OCTORELEASE} --depth 1 https://github.com/foosel/OctoPrint.git"
     fi
 	chown -R octo:octo /usr/local/lib/python2.7/dist-packages/
 	chown -R octo:octo /usr/local/bin/

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -295,6 +295,8 @@ other() {
 	echo "$VERSION $DATE" > /etc/dogtag
 	echo 'KERNEL=="uinput", GROUP="wheel", MODE:="0660"' > /etc/udev/rules.d/80-lcd-screen.rules
 	echo 'SYSFS{idVendor}=="0eef", SYSFS{idProduct}=="0001", KERNEL=="event*",SYMLINK+="input/touchscreen_eGalaxy3"' >> /etc/udev/rules.d/80-lcd-screen.rules
+	date=$(date +"%d-%m-%Y")
+	cat "Kamikaze 2.1.0 $date" > /etc/kamikaze-release
 }
 
 install_usbreset() {
@@ -414,7 +416,7 @@ dist() {
 	install_smbd
 	install_dummy_logging
 	fix_wlan
-  install_mjpgstreamer
+	install_mjpgstreamer
 }
 
 

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -156,7 +156,7 @@ install_octoprint() {
 	echo "** Install OctoPrint **" 
 	cd /home/octo
     if [ ! -d "OctoPrint" ]; then
-	    su - octo -c 'git clone --depth 1 https://github.com/foosel/OctoPrint.git'
+	     su - octo -c "git clone --branch ${OCTORELEASE} --depth 1 https://github.com/foosel/OctoPrint.git"
     fi
 	su - octo -c 'cd OctoPrint && python setup.py clean install'
 	su - octo -c 'pip install https://github.com/Salandora/OctoPrint-FileManager/archive/master.zip --user'
@@ -371,6 +371,7 @@ install_dummy_logging() {
 
 fix_wlan() {
 	sed -i 's/^\[main\]/\[main\]\ndhcp=internal/' /etc/NetworkManager/NetworkManager.conf
+	cp $WD/interfaces /etc/network/
 }
 
 install_mjpgstreamer() {

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -173,9 +173,9 @@ install_octoprint() {
 	chmod 777 /usr/share/models
 
 	# Grant octo redeem restart rights
-	echo "%octo ALL=NOPASSWD: /bin/systemctl restart redeem" >> /etc/sudoers
-	echo "%octo ALL=NOPASSWD: /bin/systemctl restart toggle" >> /etc/sudoers
-	echo "%octo ALL=NOPASSWD: /bin/systemctl restart octoprint" >> /etc/sudoers
+	echo "%octo ALL=NOPASSWD: /bin/systemctl restart redeem.service" >> /etc/sudoers
+	echo "%octo ALL=NOPASSWD: /bin/systemctl restart toggle.service" >> /etc/sudoers
+	echo "%octo ALL=NOPASSWD: /bin/systemctl restart octoprint.service" >> /etc/sudoers
 	echo "%octo ALL=NOPASSWD: /sbin/reboot" >> /etc/sudoers
 	echo "%octo ALL=NOPASSWD: /sbin/shutdown -h now" >> /etc/sudoers
 

--- a/make-kamikaze-2.1.sh
+++ b/make-kamikaze-2.1.sh
@@ -122,7 +122,7 @@ install_redeem() {
 	fi
 	cd redeem
 	git pull
-	make install
+	python setup.py clean install
 
 	# Make profiles uploadable via Octoprint
 	touch /etc/redeem/local.cfg
@@ -239,7 +239,7 @@ install_toggle() {
 		git clone --depth 1 https://bitbucket.org/intelligentagent/toggle
     	fi
 	cd toggle
-	make install
+	python setup.py clean install
 	# Make it writable for updates
 	chown -R octo:octo /usr/src/toggle/
 	cp systemd/toggle.service /lib/systemd/system/

--- a/prep_ubuntu.sh
+++ b/prep_ubuntu.sh
@@ -4,7 +4,6 @@ WD=/usr/src/Kamikaze2/
 
 network_fixes() {
 	echo "Fixing network interface config..."
-        cp $WD/interfaces /etc/network/
         sed -i 's/After=network.target auditd.service/After=auditd.service/' /etc/systemd/system/multi-user.target.wants/ssh.service
 }
 

--- a/prep_ubuntu.sh
+++ b/prep_ubuntu.sh
@@ -3,12 +3,15 @@
 WD=/usr/src/Kamikaze2/
 
 network_fixes() {
+	echo "Fixing network interface config..."
         cp $WD/interfaces /etc/network/
         sed -i 's/After=network.target auditd.service/After=auditd.service/' /etc/systemd/system/multi-user.target.wants/ssh.service
 }
 
 prep_ubuntu() {
+	echo "Upgrading packages"
 	apt-get update
+	apt-get -y upgrade
 	echo "** Preparing Ubuntu for kamikaze2 **"
 	cd /opt/scripts/tools/
 	git pull
@@ -32,6 +35,7 @@ remove_unneeded_packages() {
 }
 
 install_repo() {
+	echo "installing Kamikaze repo to the list"
 	cat >/etc/apt/sources.list.d/testing.list <<EOL
 #### Kamikaze ####
 deb [arch=armhf] http://kamikaze.thing-printer.com/debian/ stretch main

--- a/prep_ubuntu.sh
+++ b/prep_ubuntu.sh
@@ -37,10 +37,10 @@ install_repo() {
 	echo "installing Kamikaze repo to the list"
 	cat >/etc/apt/sources.list.d/testing.list <<EOL
 #### Kamikaze ####
-deb [arch=armhf] http://kamikaze.thing-printer.com/ubuntu/ xenial main
+#deb [arch=armhf] http://kamikaze.thing-printer.com/ubuntu/ xenial main
 deb [arch=armhf] http://kamikaze.thing-printer.com/debian/ stretch main
 EOL
-	wget -q http://kamikaze.thing-printer.com/ubuntu/public.gpg -O- | apt-key add -
+#	wget -q http://kamikaze.thing-printer.com/ubuntu/public.gpg -O- | apt-key add -
 	wget -q http://kamikaze.thing-printer.com/debian/public.gpg -O- | apt-key add -
 	apt-get update
 }

--- a/prep_ubuntu.sh
+++ b/prep_ubuntu.sh
@@ -37,7 +37,7 @@ install_repo() {
 	echo "installing Kamikaze repo to the list"
 	cat >/etc/apt/sources.list.d/testing.list <<EOL
 #### Kamikaze ####
-deb [arch=armhf] http://kamikaze.thing-printer.com/debian/ stretch main
+deb [arch=armhf] http://kamikaze.thing-printer.com/ubuntu/ xenial main
 EOL
 	wget -q http://kamikaze.thing-printer.com/debian/public.gpg -O- | apt-key add -
 	apt-get update

--- a/prep_ubuntu.sh
+++ b/prep_ubuntu.sh
@@ -15,6 +15,7 @@ prep_ubuntu() {
 	sh update_kernel.sh --bone-kernel --lts-4_1
 	apt-get -y upgrade
 	apt-get -y install unzip iptables
+	mkdir -p /etc/pm/sleep.d
 	touch /etc/pm/sleep.d/wireless
 	sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 }

--- a/prep_ubuntu.sh
+++ b/prep_ubuntu.sh
@@ -38,7 +38,9 @@ install_repo() {
 	cat >/etc/apt/sources.list.d/testing.list <<EOL
 #### Kamikaze ####
 deb [arch=armhf] http://kamikaze.thing-printer.com/ubuntu/ xenial main
+deb [arch=armhf] http://kamikaze.thing-printer.com/debian/ stretch main
 EOL
+	wget -q http://kamikaze.thing-printer.com/ubuntu/public.gpg -O- | apt-key add -
 	wget -q http://kamikaze.thing-printer.com/debian/public.gpg -O- | apt-key add -
 	apt-get update
 }


### PR DESCRIPTION
The current script is what was used for the creation of Kamikaze 2.1.0.

Changelog:
* Octoprint 1.3.0post1 (post1 for working setup wizard) with extra plugins:
   * FileManager plugin
   * FullFeaturedSlicer plugin
   * Sane default config file with custom actions to control Toggle and Redeem
* Latest master redeem (24/01/2017)
* Latest master toggle (24/01/2017)
* NetworkManager controls ethernet, but not USB network - USB network is '''always''' on
* Mjpg-Streamer installed by default
* SMB shares for uploading/managing folders where Octoprint stores files active by default
* Instructions to backup config before upgrade and how to restore it after the upgrade